### PR TITLE
S3 state and DynamoDB Locking configuration

### DIFF
--- a/state_config.tf
+++ b/state_config.tf
@@ -1,0 +1,9 @@
+terraform { 
+    backend "s3" {
+        bucket          = "tfstate-hachiko-app"
+        key             = "terraform-catsanddogs/state"
+        region          = "us-east-1"
+        dynamodb_table  = "terraform-state"
+        encrypt         = true
+    }
+}


### PR DESCRIPTION
Update the project to save the Terraform state in an S3 bucket and also the Lock in DynamoDB.